### PR TITLE
Print an extra space between // and the copyright text only when there's some text

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,7 +138,10 @@ func writeNoticeOn(w io.Writer) error {
 	}
 	scanner := bufio.NewScanner(strings.NewReader(notice))
 	for scanner.Scan() {
-		io.WriteString(w, "// ")
+		io.WriteString(w, "//")
+                if (len(scanner.Text()) != 0) {
+                        io.WriteString(w, " ")
+                }
 		io.WriteString(w, scanner.Text())
 		io.WriteString(w, "\n")
 	}


### PR DESCRIPTION
This avoids a bunch of "^// $" lines within the copyright section of the source file